### PR TITLE
Links to pull request commits are auto-converted incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # playground
-The name says it all.
+
+This pull request demonstrates an issue with automatic detection and conversion of commit IDs to markdown links.


### PR DESCRIPTION
### Observed behaviour

If you copy&base the following URL in the editor control at the end of this pull request thread

``` 
https://github.com/mspncp/playground/pull/3/commits/aa7cea14c709dfe772d297b68f43543a5f17c5eb
```
the editor recognizes and auto-converts it to a pretty short hash URL https://github.com/mspncp/playground/pull/3/commits/aa7cea14c709dfe772d297b68f43543a5f17c5eb. Unfortunately, that auto-converted link points to the "detached commit"

``` 
https://github.com/mspncp/playground/commit/aa7cea14c709dfe772d297b68f43543a5f17c5eb
``` 
and not to the original commit attached to the pull request, i.e., the "Files changed" view, narrowed down to that single commit.

This is inconvenient, because reviewers might follow the link and make code comments which don't become part of this pr's thread.

### Expected behaviour

Regardless of how the commit is entered by the user (text or URL), an auto-converted commit link should always link to the "pull request commit"

```
https://github.com/<user>/<repo>/pull/<pr_num>/commits/<commit_id>
```

if the commit `<commit_id>` is part of the pull request, and only otherwise to the "detached commit"

```
https://github.com/<user>/<repo>/commit/<commit_id>
```

